### PR TITLE
CanFrameFast: a wrapper around a Span<byte> to enable reads and writes without heap allocations

### DIFF
--- a/src/SocketCANSharp/CanFrameFast.cs
+++ b/src/SocketCANSharp/CanFrameFast.cs
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if NET9_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System;
 using System.Runtime.InteropServices;
 
@@ -105,4 +105,4 @@ namespace SocketCANSharp
         internal Span<byte> Buffer => _buffer;
     }
 }
-#endif // NET9_0_OR_GREATER
+#endif // NET8_0_OR_GREATER

--- a/src/SocketCANSharp/CanFrameFast.cs
+++ b/src/SocketCANSharp/CanFrameFast.cs
@@ -1,0 +1,108 @@
+#region License
+/*
+BSD 3-Clause License
+
+Copyright (c) 2025, Brill Power
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+#if NET9_0_OR_GREATER
+using System;
+using System.Runtime.InteropServices;
+
+namespace SocketCANSharp
+{
+    /// <summary>
+    /// Represents a CAN frame (classical or FD) that exists only on the stack.
+    /// </summary>
+    public readonly ref struct CanFrameFast
+    {
+        private readonly Span<byte> _buffer;
+        private readonly Span<uint> _bufferAsUint;
+
+        /// <summary>
+        /// Construct a new CanFrameFast instance with the supplied buffer.
+        /// </summary>
+        public CanFrameFast(ref Span<byte> buffer)
+        {
+            if (buffer.Length != 16 && buffer.Length != 72)
+            {
+                throw new ArgumentException("Supplied buffer is too small.");
+            }
+            _buffer = buffer;
+            _bufferAsUint = MemoryMarshal.Cast<byte, uint>(buffer);
+        }
+
+        /// <summary>
+        /// Gets a reference to the 11 or 29-bit CAN ID.
+        /// </summary>
+        public ref uint CanId
+        {
+            get { return ref _bufferAsUint[0]; }
+        }
+
+        /// <summary>
+        /// Frame length in bytes.
+        /// </summary>
+        public ref byte Length
+        {
+            get { return ref _buffer[4]; }
+        }
+
+        /// <summary>
+        /// CAN FD specific flags for ESI, BRS, etc.
+        /// </summary>
+        public CanFdFlags Flags
+        {
+            get { return (CanFdFlags)_buffer[5]; }
+            set { _buffer[5] = (byte)value; }
+        }
+
+        /// <summary>
+        /// CAN frame payload.
+        /// </summary>
+        public Span<byte> Data => _buffer.Slice(8);
+
+        /// <summary>
+        /// Gets the total size of this CAN frame (either 16 or 72 bytes).
+        /// </summary>
+        public int Size => _buffer.Length;
+
+        /// <summary>
+        /// Indexes into the payload of this CAN frame.
+        /// </summary>
+        public ref byte this[int index]
+        {
+            get { return ref _buffer[8 + index]; }
+        }
+
+        internal Span<byte> Buffer => _buffer;
+    }
+}
+#endif // NET9_0_OR_GREATER

--- a/src/SocketCANSharp/LibcNativeMethods.cs
+++ b/src/SocketCANSharp/LibcNativeMethods.cs
@@ -157,7 +157,7 @@ namespace SocketCANSharp
         /// <param name="frameSize">Size of the buffer in bytes</param>
         /// <returns>The number of bytes written on success, -1 on error</returns>
         [DllImport("libc", EntryPoint = "write", SetLastError = true)]
-        public static extern int Write(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
+        internal static extern int Write(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
 #endif // NET9_0_OR_GREATER
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace SocketCANSharp
         /// <param name="frameSize">Size of byte buffer</param>
         /// <returns>The number of bytes read on success, -1 on error</returns>
         [DllImport("libc", EntryPoint = "read", SetLastError = true)]
-        public static extern int Read(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
+        internal static extern int Read(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
 #endif // NET9_0_OR_GREATER
 
         /// <summary>

--- a/src/SocketCANSharp/LibcNativeMethods.cs
+++ b/src/SocketCANSharp/LibcNativeMethods.cs
@@ -148,7 +148,7 @@ namespace SocketCANSharp
         [DllImport("libc", EntryPoint="connect", SetLastError=true)]
         public static extern int Connect(SafeFileDescriptorHandle socketHandle, SockAddrCanJ1939 addr, int addrSize);
 
-#if NET9_0_OR_GREATER
+#if NET8_0_OR_GREATER
         /// <summary>
         /// Write the contents of a byte buffer to the socket.
         /// </summary>
@@ -158,7 +158,7 @@ namespace SocketCANSharp
         /// <returns>The number of bytes written on success, -1 on error</returns>
         [DllImport("libc", EntryPoint = "write", SetLastError = true)]
         internal static extern int Write(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
-#endif // NET9_0_OR_GREATER
+#endif // NET8_0_OR_GREATER
 
         /// <summary>
         /// Write the CanFrame to the socket.
@@ -300,7 +300,7 @@ namespace SocketCANSharp
         [DllImport("libc", EntryPoint="write", SetLastError=true)]
         public static extern int Write(SafeFileDescriptorHandle socketHandle, byte[] data, int dataSize);
 
-#if NET9_0_OR_GREATER
+#if NET8_0_OR_GREATER
         /// <summary>
         /// Read into a byte buffer from the socket.
         /// </summary>
@@ -310,7 +310,7 @@ namespace SocketCANSharp
         /// <returns>The number of bytes read on success, -1 on error</returns>
         [DllImport("libc", EntryPoint = "read", SetLastError = true)]
         internal static extern int Read(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
-#endif // NET9_0_OR_GREATER
+#endif // NET8_0_OR_GREATER
 
         /// <summary>
         /// Read a CanFrame from the socket.

--- a/src/SocketCANSharp/LibcNativeMethods.cs
+++ b/src/SocketCANSharp/LibcNativeMethods.cs
@@ -1,5 +1,5 @@
 #region License
-/* 
+/*
 BSD 3-Clause License
 
 Copyright (c) 2021, Derek Will
@@ -28,7 +28,7 @@ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
@@ -89,7 +89,7 @@ namespace SocketCANSharp
         public static extern int Ioctl(SafeFileDescriptorHandle socketHandle, int request, [In][Out] IfreqMtu ifreq);
 
         /// <summary>
-        /// Used to obtain a timeval struct with the receive timestamp of the last packet passed to the user. 
+        /// Used to obtain a timeval struct with the receive timestamp of the last packet passed to the user.
         /// </summary>
         /// <param name="socketHandle">Socket Handle Wrapper Instance</param>
         /// <param name="request">Request Code</param>
@@ -147,7 +147,19 @@ namespace SocketCANSharp
         /// <returns>0 on success, -1 on error</returns>
         [DllImport("libc", EntryPoint="connect", SetLastError=true)]
         public static extern int Connect(SafeFileDescriptorHandle socketHandle, SockAddrCanJ1939 addr, int addrSize);
- 
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Write the contents of a byte buffer to the socket.
+        /// </summary>
+        /// <param name="socketHandle">Socket Handle Wrappper Instance</param>
+        /// <param name="frame">Reference to a buffer to write</param>
+        /// <param name="frameSize">Size of the buffer in bytes</param>
+        /// <returns>The number of bytes written on success, -1 on error</returns>
+        [DllImport("libc", EntryPoint = "write", SetLastError = true)]
+        public static extern int Write(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
+#endif // NET9_0_OR_GREATER
+
         /// <summary>
         /// Write the CanFrame to the socket.
         /// </summary>
@@ -288,6 +300,18 @@ namespace SocketCANSharp
         [DllImport("libc", EntryPoint="write", SetLastError=true)]
         public static extern int Write(SafeFileDescriptorHandle socketHandle, byte[] data, int dataSize);
 
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Read into a byte buffer from the socket.
+        /// </summary>
+        /// <param name="socketHandle">Socket Handle Wrapper Instance</param>
+        /// <param name="frame">A reference to a byte buffer to populate</param>
+        /// <param name="frameSize">Size of byte buffer</param>
+        /// <returns>The number of bytes read on success, -1 on error</returns>
+        [DllImport("libc", EntryPoint = "read", SetLastError = true)]
+        public static extern int Read(SafeFileDescriptorHandle socketHandle, ref byte frame, int frameSize);
+#endif // NET9_0_OR_GREATER
+
         /// <summary>
         /// Read a CanFrame from the socket.
         /// </summary>
@@ -337,7 +361,7 @@ namespace SocketCANSharp
         /// <returns>The number of bytes read on success, -1 on error</returns>
         [DllImport("libc", EntryPoint="read", SetLastError=true)]
         public static extern int Read(SafeFileDescriptorHandle socketHandle, [Out] BcmGenericMessage message, int msgSize);
-        
+
         /// <summary>
         /// Read a BcmGenericMessage from the socket. Variant for 32-bit.
         /// </summary>
@@ -715,7 +739,7 @@ namespace SocketCANSharp
         /// <returns>0 or 1 on success depending on option name and value, -1 on error</returns>
         [DllImport("libc", EntryPoint="setsockopt", SetLastError=true)]
         public static extern int SetSockOpt(SafeFileDescriptorHandle socketHandle, SocketLevel socketLevel, J1939SocketOptions optionName, ref int optionValue, int optionValueSize);
-        
+
         /// <summary>
         /// Get the socket option specified by the option name and socket level to the provided option value for the supplied socket.
         /// </summary>
@@ -751,7 +775,7 @@ namespace SocketCANSharp
         /// <returns>0 on success, -1 on error</returns>
         [DllImport("libc", EntryPoint="getsockopt", SetLastError=true)]
         public static extern int GetSockOpt(SafeFileDescriptorHandle socketHandle, SocketLevel socketLevel, J1939SocketOptions optionName, [In, Out] J1939Filter[] filters, ref int optionValueSize);
-        
+
         /// <summary>
         /// Set the socket option specified by the option name and socket level to the provided option value for the supplied socket.
         /// </summary>
@@ -775,7 +799,7 @@ namespace SocketCANSharp
         /// <returns>0 on success, -1 on error</returns>
         [DllImport("libc", EntryPoint = "getsockopt", SetLastError = true)]
         public static extern int GetSockOpt(SafeFileDescriptorHandle socketHandle, SocketLevel socketLevel, int optionName, IntPtr optionValue, ref int optionValueSize);
-        
+
         /// <summary>
         /// Set the socket option specified by the option name and socket level to the provided option value for the supplied socket.
         /// </summary>
@@ -817,12 +841,12 @@ namespace SocketCANSharp
         /// <summary>
         /// Opens an epoll file descriptor.
         /// </summary>
-        /// <param name="size">The size argument is ignored since Linux 2.6.8, but must be greater than zero for backwards compatibility. 
+        /// <param name="size">The size argument is ignored since Linux 2.6.8, but must be greater than zero for backwards compatibility.
         /// Originally, this argument was intended as a hint to the kernel as to the number of file descriptors that the caller expected to add to the epoll instance.</param>
         /// <returns>On success, returns a valid file descriptor handle. On failure, returns an invalid file descriptor handle.</returns>
         [DllImport("libc", EntryPoint="epoll_create", SetLastError=true)]
         public static extern SafeFileDescriptorHandle EpollCreate(int size);
-        
+
         /// <summary>
         /// Control interface used to add, modify, and delete entries from the interest list of an epoll file descriptor.
         /// </summary>
@@ -833,7 +857,7 @@ namespace SocketCANSharp
         /// <returns>0 on success, -1 on error</returns>
         [DllImport("libc", EntryPoint="epoll_ctl", SetLastError=true)]
         public static extern int EpollControl(SafeFileDescriptorHandle epfd, EpollOperation op, SafeFileDescriptorHandle fd, ref EpollEvent evnt);
-        
+
         /// <summary>
         /// Waits for an I/O event on an epoll file descriptor.
         /// </summary>
@@ -902,7 +926,7 @@ namespace SocketCANSharp
         /// <returns>The number of bytes received on success, -1 on error</returns>
         [DllImport("libc", EntryPoint="recvmsg", SetLastError=true)]
         public static extern int RecvMsg(SafeFileDescriptorHandle socketHandle, ref MessageHeader canMessage, MessageFlags flags);
-        
+
         /// <summary>
         /// Retrieves the index of the network interface corresponding to the specified name.
         /// </summary>

--- a/src/SocketCANSharp/Network/RawCanSocket.cs
+++ b/src/SocketCANSharp/Network/RawCanSocket.cs
@@ -213,7 +213,7 @@ namespace SocketCANSharp.Network
             });
         }
 
-#if NET9_0_OR_GREATER
+#if NET8_0_OR_GREATER
         /// <summary>
         /// Writes the supplied CAN Frame to the socket.
         /// </summary>
@@ -232,7 +232,7 @@ namespace SocketCANSharp.Network
 
             return bytesWritten;
         }
-#endif // NET9_0_OR_GREATER
+#endif // NET8_0_OR_GREATER
 
         /// <summary>
         /// Writes the supplied Classical CAN Frame to the socket.
@@ -291,7 +291,7 @@ namespace SocketCANSharp.Network
             return bytesWritten;
         }
 
-#if NET9_0_OR_GREATER
+#if NET8_0_OR_GREATER
         /// <summary>
         /// Reads a Classical CAN Frame from the socket.
         /// </summary>
@@ -310,7 +310,7 @@ namespace SocketCANSharp.Network
 
             return bytesRead;
         }
-#endif // NET9_0_OR_GREATER
+#endif // NET8_0_OR_GREATER
 
         /// <summary>
         /// Reads a Classical CAN Frame from the socket.

--- a/src/SocketCANSharp/Network/RawCanSocket.cs
+++ b/src/SocketCANSharp/Network/RawCanSocket.cs
@@ -1,5 +1,5 @@
 #region License
-/* 
+/*
 BSD 3-Clause License
 
 Copyright (c) 2022, Derek Will
@@ -28,7 +28,7 @@ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
@@ -57,7 +57,7 @@ namespace SocketCANSharp.Network
         /// <summary>
         /// CAN Filters to control the reception of CAN frames.
         /// </summary>
-        public CanFilter[] CanFilters 
+        public CanFilter[] CanFilters
         {
             get
             {
@@ -72,7 +72,7 @@ namespace SocketCANSharp.Network
         /// <summary>
         /// Error Mask to filter which Error Message Frames are passed to the socket receive queue.
         /// </summary>
-        public CanErrorClass ErrorFilters 
+        public CanErrorClass ErrorFilters
         {
             get
             {
@@ -87,7 +87,7 @@ namespace SocketCANSharp.Network
         /// <summary>
         /// Local loopback to receive messages sent from other sockets on this CAN node.
         /// </summary>
-        public bool LocalLoopback 
+        public bool LocalLoopback
         {
             get
             {
@@ -102,7 +102,7 @@ namespace SocketCANSharp.Network
         /// <summary>
         /// Enables a socket to receive the messages that it sent itself.
         /// </summary>
-        public bool ReceiveOwnMessages 
+        public bool ReceiveOwnMessages
         {
             get
             {
@@ -117,7 +117,7 @@ namespace SocketCANSharp.Network
         /// <summary>
         /// Allows the socket to handle CAN FD frames.
         /// </summary>
-        public bool EnableCanFdFrames 
+        public bool EnableCanFdFrames
         {
             get
             {
@@ -132,7 +132,7 @@ namespace SocketCANSharp.Network
         /// <summary>
         /// Allows the socket to handle CAN XL frames.
         /// </summary>
-        public bool EnableCanXlFrames 
+        public bool EnableCanXlFrames
         {
             get
             {
@@ -146,9 +146,9 @@ namespace SocketCANSharp.Network
 
 
         /// <summary>
-        /// If true, then all CAN filters must match (logical AND) for a CAN frame to be placed into the receive queue. If false, then if any CAN filter matches (logical OR) then a CAN frame will be placed into the receive queue. 
+        /// If true, then all CAN filters must match (logical AND) for a CAN frame to be placed into the receive queue. If false, then if any CAN filter matches (logical OR) then a CAN frame will be placed into the receive queue.
         /// </summary>
-        public bool AllCanFiltersMustMatch 
+        public bool AllCanFiltersMustMatch
         {
             get
             {
@@ -173,7 +173,7 @@ namespace SocketCANSharp.Network
             if (SafeHandle.IsInvalid)
                 throw new SocketCanException("Failed to create CAN_RAW socket.");
         }
-        
+
         /// <summary>
         /// Assigns the SocketCAN Base Address Structure to the CAN_RAW socket.
         /// </summary>
@@ -203,7 +203,7 @@ namespace SocketCANSharp.Network
         /// <exception cref="ArgumentNullException">CanNetworkInterface instance is null.</exception>
         public void Bind(CanNetworkInterface iface)
         {
-            if (iface == null) 
+            if (iface == null)
                 throw new ArgumentNullException(nameof(iface));
 
             Bind(new SockAddrCan()
@@ -212,6 +212,27 @@ namespace SocketCANSharp.Network
                 CanIfIndex = iface.Index,
             });
         }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Writes the supplied CAN Frame to the socket.
+        /// </summary>
+        /// <param name="canFrame">CAN Frame to transmit onto the CAN network.</param>
+        /// <returns>Number of bytes written to the socket.</returns>
+        /// <exception cref="ObjectDisposedException">The socket has been closed.</exception>
+        /// <exception cref="SocketCanException">Writing to the underlying CAN_RAW socket failed.</exception>
+        public int Write(ref CanFrameFast canFrame)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
+            int bytesWritten = LibcNativeMethods.Write(SafeHandle, ref MemoryMarshal.GetReference(canFrame.Buffer), canFrame.Size);
+            if (bytesWritten == -1)
+                throw new SocketCanException("Writing to the underlying CAN_RAW socket failed.");
+
+            return bytesWritten;
+        }
+#endif // NET9_0_OR_GREATER
 
         /// <summary>
         /// Writes the supplied Classical CAN Frame to the socket.
@@ -269,6 +290,27 @@ namespace SocketCANSharp.Network
 
             return bytesWritten;
         }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Reads a Classical CAN Frame from the socket.
+        /// </summary>
+        /// <param name="canFrame">Classical CAN Frame to receive from the CAN network.</param>
+        /// <returns>Number of bytes read from the socket.</returns>
+        /// <exception cref="ObjectDisposedException">The socket has been closed.</exception>
+        /// <exception cref="SocketCanException">Reading from the underlying CAN_RAW socket failed.</exception>
+        public int Read(ref CanFrameFast canFrame)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
+            int bytesRead = LibcNativeMethods.Read(SafeHandle, ref MemoryMarshal.GetReference(canFrame.Buffer), canFrame.Size);
+            if (bytesRead == -1)
+                throw new SocketCanException("Reading from the underlying CAN_RAW socket failed.");
+
+            return bytesRead;
+        }
+#endif // NET9_0_OR_GREATER
 
         /// <summary>
         /// Reads a Classical CAN Frame from the socket.
@@ -389,7 +431,7 @@ namespace SocketCANSharp.Network
             int len = canFilterArray != null ? Marshal.SizeOf(typeof(CanFilter)) * canFilterArray.Length : 0;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_FILTER, canFilterArray, len);
             if (result != 0)
-                throw new SocketCanException("Unable to set CAN_RAW_FILTER on CAN_RAW socket.");    
+                throw new SocketCanException("Unable to set CAN_RAW_FILTER on CAN_RAW socket.");
         }
 
         private CanFilter[] GetRawCanFilters()
@@ -430,14 +472,14 @@ namespace SocketCANSharp.Network
             uint err_mask = (uint)errorMask;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_ERR_FILTER, ref err_mask, Marshal.SizeOf(err_mask));
             if (result != 0)
-                throw new SocketCanException("Unable to set CAN_RAW_ERR_FILTER on CAN_RAW socket."); 
+                throw new SocketCanException("Unable to set CAN_RAW_ERR_FILTER on CAN_RAW socket.");
         }
 
         private CanErrorClass GetRawCanErrorFrameFilters()
         {
             if (_disposed)
                 throw new ObjectDisposedException(GetType().FullName);
-            
+
             uint err_mask = 0;
             int len = Marshal.SizeOf(err_mask);
             int result = LibcNativeMethods.GetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_ERR_FILTER, ref err_mask, ref len);
@@ -455,7 +497,7 @@ namespace SocketCANSharp.Network
 
             int loopback = enable ? 1 : 0;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_LOOPBACK, ref loopback, Marshal.SizeOf(loopback));
-            
+
             if (result != 0)
                 throw new SocketCanException("Unable to set CAN_RAW_LOOPBACK on CAN_RAW socket.");
         }
@@ -482,7 +524,7 @@ namespace SocketCANSharp.Network
 
             int recv_own_msgs = enable ? 1 : 0;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_RECV_OWN_MSGS, ref recv_own_msgs, Marshal.SizeOf(recv_own_msgs));
-            
+
             if (result != 0)
                 throw new SocketCanException("Unable to set CAN_RAW_RECV_OWN_MSGS on CAN_RAW socket.");
         }
@@ -509,7 +551,7 @@ namespace SocketCANSharp.Network
 
             int can_fd_enabled = enable ? 1 : 0;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_FD_FRAMES, ref can_fd_enabled, Marshal.SizeOf(can_fd_enabled));
-            
+
             if (result != 0)
                 throw new SocketCanException("Unable to set CAN_RAW_FD_FRAMES on CAN_RAW socket.");
         }
@@ -536,7 +578,7 @@ namespace SocketCANSharp.Network
 
             int can_xl_enabled = enable ? 1 : 0;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_XL_FRAMES, ref can_xl_enabled, Marshal.SizeOf<int>());
-            
+
             if (result != 0)
                 throw new SocketCanException("Unable to set CAN_RAW_XL_FRAMES on CAN_RAW socket.");
         }
@@ -563,7 +605,7 @@ namespace SocketCANSharp.Network
 
             int join_filter = enable ? 1 : 0;
             int result = LibcNativeMethods.SetSockOpt(SafeHandle, SocketLevel.SOL_CAN_RAW, CanSocketOptions.CAN_RAW_JOIN_FILTERS, ref join_filter, Marshal.SizeOf(join_filter));
-            
+
             if (result != 0)
                 throw new SocketCanException("Unable to set CAN_RAW_JOIN_FILTERS on CAN_RAW socket.");
         }
@@ -600,12 +642,12 @@ namespace SocketCANSharp.Network
 
         private int Read<T>(out T frame, out bool txSuccess, out bool localhost)
         {
-            int ctrlMsgSize = ControlMessageMacros.CMSG_SPACE(Marshal.SizeOf<Timeval>()) + ControlMessageMacros.CMSG_SPACE(Marshal.SizeOf<UInt32>());     
+            int ctrlMsgSize = ControlMessageMacros.CMSG_SPACE(Marshal.SizeOf<Timeval>()) + ControlMessageMacros.CMSG_SPACE(Marshal.SizeOf<UInt32>());
             IntPtr addrPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SockAddrCan>());
             IntPtr iovecPtr = Marshal.AllocHGlobal(Marshal.SizeOf<IoVector>());
             IntPtr framePtr = Marshal.AllocHGlobal(Marshal.SizeOf<T>());
             IntPtr ctrlMsgPtr = Marshal.AllocHGlobal(ctrlMsgSize);
-            
+
             try
             {
                 var iovec = new IoVector() { Base = framePtr, Length = new IntPtr(Marshal.SizeOf<T>()) };

--- a/src/SocketCANSharp/SocketCANSharp.csproj
+++ b/src/SocketCANSharp/SocketCANSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyName>SocketCANSharp</AssemblyName>
     <Version>0.13.0.0</Version>

--- a/src/SocketCANSharp/SocketCANSharp.csproj
+++ b/src/SocketCANSharp/SocketCANSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AssemblyName>SocketCANSharp</AssemblyName>
     <Version>0.13.0.0</Version>

--- a/test/SocketCANSharpTest/RawCanSocketTests.cs
+++ b/test/SocketCANSharpTest/RawCanSocketTests.cs
@@ -39,6 +39,7 @@ using SocketCANSharp.Network;
 using System.Net.Sockets;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace SocketCANSharpTest
 {
@@ -1202,6 +1203,73 @@ namespace SocketCANSharpTest
                 data.CopyTo(writeFrame.Data);
                 int bytesWritten = rawCanSocket.Write(ref writeFrame);
                 Assert.AreEqual(16, bytesWritten);
+            }
+        }
+
+        [Test]
+        public void RawCanSocket_Write_CanFrameFast_Fd_Success_Test()
+        {
+            IEnumerable<CanNetworkInterface> collection = CanNetworkInterface.GetAllInterfaces(true);
+            Assert.IsNotNull(collection);
+            Assert.GreaterOrEqual(collection.Count(), 1);
+
+            var iface = collection.FirstOrDefault(i =>  i.Name.Equals("vcan0"));
+            Assert.IsNotNull(iface);
+
+            using (var rawCanSocket = new RawCanSocket())
+            {
+                Assume.That(iface.MaximumTransmissionUnit, Is.GreaterThanOrEqualTo(SocketCanConstants.CANFD_MTU));
+                rawCanSocket.EnableCanFdFrames = true;
+                rawCanSocket.Bind(iface);
+
+                byte[] data = [ 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef ];
+                Span<byte> write = stackalloc byte[72];
+                CanFrameFast writeFrame = new CanFrameFast(ref write);
+                writeFrame.CanId = 0x123;
+                writeFrame.Length = (byte)data.Length;
+                writeFrame.Flags = CanFdFlags.CANFD_BRS;
+                data.CopyTo(writeFrame.Data);
+                int bytesWritten = rawCanSocket.Write(ref writeFrame);
+                Assert.AreEqual(72, bytesWritten);
+            }
+        }
+
+        [Test]
+        public void RawCanSocket_Read_CanFrameFast_Fd_Success_Test()
+        {
+            IEnumerable<CanNetworkInterface> collection = CanNetworkInterface.GetAllInterfaces(true);
+            Assert.IsNotNull(collection);
+            Assert.GreaterOrEqual(collection.Count(), 1);
+
+            var iface = collection.FirstOrDefault(i =>  i.Name.Equals("vcan0"));
+            Assert.IsNotNull(iface);
+
+            using (var senderSocket = new RawCanSocket())
+            using (var receiverSocket = new RawCanSocket())
+            {
+                Assume.That(iface.MaximumTransmissionUnit, Is.GreaterThanOrEqualTo(SocketCanConstants.CANFD_MTU));
+                senderSocket.EnableCanFdFrames = true;
+                receiverSocket.EnableCanFdFrames = true;
+                senderSocket.Bind(iface);
+                receiverSocket.Bind(iface);
+
+                byte[] data = [ 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef ];
+                Span<byte> write = stackalloc byte[72];
+                CanFrameFast writeFrame = new CanFrameFast(ref write);
+                writeFrame.CanId = 0x123;
+                writeFrame.Length = (byte)data.Length;
+                writeFrame.Flags = CanFdFlags.CANFD_BRS;
+                data.CopyTo(writeFrame.Data);
+                int bytesWritten = senderSocket.Write(ref writeFrame);
+                Assert.AreEqual(72, bytesWritten);
+
+                Span<byte> read = stackalloc byte[72];
+                CanFrameFast readFrame = new CanFrameFast(ref read);
+                int bytesRead = receiverSocket.Read(ref readFrame);
+                Assert.AreEqual(72, bytesRead);
+                Assert.AreEqual(0x123, readFrame.CanId);
+                Assert.IsTrue(readFrame.Data.ToArray().Take(readFrame.Length).SequenceEqual(new byte[] { 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef }));
+                Assert.IsTrue(readFrame.Flags.HasFlag(CanFdFlags.CANFD_BRS)); // In Kernel 6.1 and higher - CANFD_FDF flag will also be set. Changing to just check for BRS to be backwards compatible.
             }
         }
     }

--- a/test/SocketCANSharpTest/RawCanSocketTests.cs
+++ b/test/SocketCANSharpTest/RawCanSocketTests.cs
@@ -1,5 +1,5 @@
 #region License
-/* 
+/*
 BSD 3-Clause License
 
 Copyright (c) 2022, Derek Will
@@ -28,7 +28,7 @@ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
@@ -269,7 +269,7 @@ namespace SocketCANSharpTest
             {
                 rawCanSocket.ErrorFilters = CanErrorClass.CAN_ERR_ACK | CanErrorClass.CAN_ERR_BUSERROR;
                 CanErrorClass errFilters = rawCanSocket.ErrorFilters;
-                Assert.IsTrue(errFilters.HasFlag(CanErrorClass.CAN_ERR_ACK));  
+                Assert.IsTrue(errFilters.HasFlag(CanErrorClass.CAN_ERR_ACK));
                 Assert.IsTrue(errFilters.HasFlag(CanErrorClass.CAN_ERR_BUSERROR));
                 Assert.IsFalse(errFilters.HasFlag(CanErrorClass.CAN_ERR_BUSOFF));
                 Assert.IsFalse(errFilters.HasFlag(CanErrorClass.CAN_ERR_CRTL));
@@ -319,7 +319,7 @@ namespace SocketCANSharpTest
                 rawCanSocket.Bind(iface);
                 rawCanSocket.ErrorFilters = CanErrorClass.CAN_ERR_ACK | CanErrorClass.CAN_ERR_BUSERROR;
                 CanErrorClass errFilters = rawCanSocket.ErrorFilters;
-                Assert.IsTrue(errFilters.HasFlag(CanErrorClass.CAN_ERR_ACK));  
+                Assert.IsTrue(errFilters.HasFlag(CanErrorClass.CAN_ERR_ACK));
                 Assert.IsTrue(errFilters.HasFlag(CanErrorClass.CAN_ERR_BUSERROR));
                 Assert.IsFalse(errFilters.HasFlag(CanErrorClass.CAN_ERR_BUSOFF));
                 Assert.IsFalse(errFilters.HasFlag(CanErrorClass.CAN_ERR_CRTL));
@@ -1143,6 +1143,65 @@ namespace SocketCANSharpTest
                 Assert.IsTrue(data.SequenceEqual(frame2.Data.Take(frame2.Length)));
                 Assert.AreEqual(false, txSuccess2);
                 Assert.AreEqual(true, localhost2);
+            }
+        }
+
+        [Test]
+        public void RawCanSocket_Read_CanFrameFast_Success_Test()
+        {
+            IEnumerable<CanNetworkInterface> collection = CanNetworkInterface.GetAllInterfaces(true);
+            Assert.IsNotNull(collection);
+            Assert.GreaterOrEqual(collection.Count(), 1);
+
+            var iface = collection.FirstOrDefault(i =>  i.Name.Equals("vcan0"));
+            Assert.IsNotNull(iface);
+
+            using (var senderSocket = new RawCanSocket())
+            using (var receiverSocket = new RawCanSocket())
+            {
+                senderSocket.Bind(iface);
+                receiverSocket.Bind(iface);
+
+                byte[] data = [ 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef ];
+                Span<byte> write = stackalloc byte[16];
+                CanFrameFast writeFrame = new CanFrameFast(ref write);
+                writeFrame.CanId = 0x123;
+                writeFrame.Length = (byte)data.Length;
+                data.CopyTo(writeFrame.Data);
+                int bytesWritten = senderSocket.Write(ref writeFrame);
+                Assert.AreEqual(16, bytesWritten);
+
+                Span<byte> read = stackalloc byte[16];
+                CanFrameFast readFrame = new CanFrameFast(ref read);
+                int bytesRead = receiverSocket.Read(ref readFrame);
+                Assert.AreEqual(16, bytesRead);
+                Assert.AreEqual(0x123, readFrame.CanId);
+                Assert.IsTrue(readFrame.Data.ToArray().Take(readFrame.Length).SequenceEqual(new byte[] { 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef }));
+            }
+        }
+
+        [Test]
+        public void RawCanSocket_Write_CanFrameFast_Success_Test()
+        {
+            IEnumerable<CanNetworkInterface> collection = CanNetworkInterface.GetAllInterfaces(true);
+            Assert.IsNotNull(collection);
+            Assert.GreaterOrEqual(collection.Count(), 1);
+
+            var iface = collection.FirstOrDefault(i =>  i.Name.Equals("vcan0"));
+            Assert.IsNotNull(iface);
+
+            using (var rawCanSocket = new RawCanSocket())
+            {
+                rawCanSocket.Bind(iface);
+
+                byte[] data = [ 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef ];
+                Span<byte> write = stackalloc byte[16];
+                CanFrameFast writeFrame = new CanFrameFast(ref write);
+                writeFrame.CanId = 0x123;
+                writeFrame.Length = (byte)data.Length;
+                data.CopyTo(writeFrame.Data);
+                int bytesWritten = rawCanSocket.Write(ref writeFrame);
+                Assert.AreEqual(16, bytesWritten);
             }
         }
     }

--- a/test/SocketCANSharpTest/SocketCANSharpTest.csproj
+++ b/test/SocketCANSharpTest/SocketCANSharpTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/SocketCANSharpTest/SocketCANSharpTest.csproj
+++ b/test/SocketCANSharpTest/SocketCANSharpTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- add overloads to `RawCanSocket`
- add relevant overloads to `LibcNativeMethods` (but make `internal` as the signature is very open)
- port a few `CanFrame` and `CanFdFrame` tests
- .NET 8 or later only